### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ToyView
 Draw animation
 
-##Arc
+## Arc
 ![](gif/demo1.gif)
 
-##Square bilibili
+## Square bilibili
 ![](gif/demo2.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
